### PR TITLE
Added version number to manifest.json

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -4,5 +4,6 @@
     "documentation": "https://www.github.com/timothybrown/hass-systemd",
     "dependencies": [],
     "codeowners": ["@timothybrown"],
-    "requirements": ["systemd-python>=234"]
+    "requirements": ["systemd-python>=234"],
+    "version": "0.2.1"
 }


### PR DESCRIPTION
This is required starting with Home Assistant 2021.6, see
https://developers.home-assistant.io/blog/2021/01/29/custom-integration-changes/#versions

(I intentionally did not update the version number at the top of the README file, nor the changelog at the bottom. You may want to do it before actually making a release if you merge my patch.)

Thanks for making this integration available!